### PR TITLE
docs/build/ci: fix link to PHIR spec; update `phir`, add `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pytket-phir
 
 PHIR stands for _[PECOS](https://github.com/PECOS-packages/PECOS) High-level Intermediate Representation_.
-See [PHIR specification](https://github.com/CQCL/phir/blob/main/phir_spec_qasm.md) for more.
+See [PHIR specification](https://github.com/CQCL/phir/blob/main/spec.md) for more.
 
 ## Installation
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ pytket-phir
 
 PHIR stands for `PECOS <https://github.com/PECOS-packages/PECOS>`__
 *High-level Intermediate Representation*. See `PHIR
-specification <https://github.com/CQCL/phir/blob/main/phir_spec_qasm.md>`__
+specification <https://github.com/CQCL/phir/blob/main/spec.md>`__
 for more.
 
 Indices and tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,18 @@ requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [{name = "Quantinuum"}]
 
-dependencies = ["phir>=0.1.5", "pytket"]
+classifiers = [
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Typing :: Typed",
+]
+
+dependencies = ["phir>=0.1.6", "pytket"]
 
 [project.optional-dependencies]
 tests = ["pytest"]

--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -149,7 +149,7 @@ def append_cmd(cmd: tk.Command, ops: list[dict[str, Any]]) -> None:
 
             case tk.BarrierOp():
                 # TODO(kartik): confirm with Ciaran/spec
-                # https://github.com/CQCL/phir/blob/main/phir_spec_qasm.md
+                # https://github.com/CQCL/phir/blob/main/spec.md
                 logger.debug("Skipping Barrier instruction")
 
             case tk.Conditional():  # where the condition is equality check

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 build==1.0.3
 mypy==1.6.1
-phir==0.1.5
+phir==0.1.6
 pre-commit==3.5.0
 pytest==7.4.3
 pytket-quantinuum==0.25.0


### PR DESCRIPTION
- docs: fix link to PHIR spec
	- To sync with upstream change https://github.com/CQCL/phir/commit/41433c82fe6f2d609ecff7bc7f6b4df9276aa8bb
- build: update phir version, add classifiers
- ci: Add `dependabot.yml` for automatic dependency updates