### PR TITLE
Rename `Layer` -> `ShardLayer`, and introduce another `Layer` type

### DIFF
--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -8,7 +8,7 @@ from phir.model import PHIRModel
 from pytket.circuit.logic_exp import RegWiseOp
 from pytket.unit_id import UnitID
 
-from .sharding.shard import Cost, Layer, Ordering
+from .sharding.shard import Cost, Ordering, ShardLayer
 
 logger = logging.getLogger(__name__)
 
@@ -235,7 +235,7 @@ def append_cmd(cmd: tk.Command, ops: list[dict[str, Any]]) -> None:
 
 
 def genphir(
-    inp: list[tuple[Ordering, Layer, Cost]], *, machine_ops: bool = True
+    inp: list[tuple[Ordering, ShardLayer, Cost]], *, machine_ops: bool = True
 ) -> str:
     """Convert a list of shards to the equivalent PHIR.
 

--- a/pytket/phir/place_and_route.py
+++ b/pytket/phir/place_and_route.py
@@ -1,14 +1,14 @@
 from .machine import Machine
 from .placement import optimized_place
 from .routing import transport_cost
-from .sharding.shard import Cost, Layer, Ordering, Shard
+from .sharding.shard import Cost, Ordering, Shard, ShardLayer
 from .sharding.shards2ops import parse_shards_naive
 
 
 def place_and_route(
     shards: list[Shard],
     machine: Machine | None = None,
-) -> list[tuple[Ordering, Layer, Cost]]:
+) -> list[tuple[Ordering, ShardLayer, Cost]]:
     """Get all the routing info needed for PHIR generation."""
     shard_set = set(shards)
     circuit_rep, shard_layers = parse_shards_naive(shard_set)

--- a/pytket/phir/placement.py
+++ b/pytket/phir/placement.py
@@ -37,7 +37,7 @@ def placement_check(
 
     # If there are no operations to place, it does not matter where the
     # qubits are and any placement is valid
-    if len(ops) == 0:
+    if not ops:
         return True
 
     # assume ops look like this [[1,2],[3],[4],[5,6],[7],[8],[9,10]]

--- a/pytket/phir/sharding/shard.py
+++ b/pytket/phir/sharding/shard.py
@@ -61,5 +61,5 @@ class Shard:
 
 
 Cost: TypeAlias = float
-Layer: TypeAlias = list[Shard]
+ShardLayer: TypeAlias = list[Shard]
 Ordering: TypeAlias = list[int]

--- a/pytket/phir/sharding/shards2ops.py
+++ b/pytket/phir/sharding/shards2ops.py
@@ -1,20 +1,27 @@
-from .shard import Shard
+from typing import TypeAlias
+
+from .shard import Shard, ShardLayer
+
+Layer: TypeAlias = list[list[int]]
 
 
 def parse_shards_naive(
     shards: set[Shard],
-) -> tuple[list[list[list[int]]], list[list[Shard]]]:
+) -> tuple[list[Layer], list[ShardLayer]]:
     """Parse a set of shards and return a circuit representation for placement."""
-    layers: list[list[list[int]]] = []
-    shards_in_layer: list[list[Shard]] = []
+    layers: list[Layer] = []
+    shards_in_layer: list[ShardLayer] = []
     scheduled: set[int] = set()
     num_shards: int = len(shards)
 
     while len(scheduled) < num_shards:
-        layer: list[list[int]] = []
+        layer: Layer = []
+
         # Iterate the shards, looking for shards whose dependencies have been
         # satisfied, or initially, shards with no dependencies
-        to_schedule = [s for s in shards if s.depends_upon.issubset(scheduled)]
+        to_schedule: ShardLayer = [
+            s for s in shards if s.depends_upon.issubset(scheduled)
+        ]
         shards_in_layer.append(to_schedule)
         shards.difference_update(to_schedule)
 


### PR DESCRIPTION
We seem to have two different notions of layers, so I am renaming the previous `Layer` type to `ShardLayer` and introducing another `Layer` type to make the return type of `parse_shards_naive` concise.

Other suggestions welcome!