### PR TITLE
ci: Remove redundant deps from commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Learned from https://github.com/CQCL/phir/pull/17 and https://github.com/CQCL/phir/pull/18 that the prefix is redundant.