### PR TITLE
build: add missing dep, correct Python constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 name = "pytket-phir"
 description = "A circuit analyzer and translator from pytket to PHIR"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.12"
 license = {file = "LICENSE"}
 authors = [{name = "Quantinuum"}]
 
@@ -23,7 +23,11 @@ classifiers = [
   "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["phir>=0.1.6", "pytket"]
+dependencies = [
+  "phir>=0.1.6",
+  "pytket-quantinuum",
+  "pytket",
+  ]
 
 [project.optional-dependencies]
 docs = ["sphinx", "pydata_sphinx_theme"]


### PR DESCRIPTION
Installation from PyPI currently fails with two errors:
```py
❯ phirc -v
Traceback (most recent call last):
  File "/private/tmp/.venv/bin/phirc", line 5, in <module>
    from pytket.phir.cli import main
  File "/private/tmp/.venv/lib/python3.11/site-packages/pytket/phir/cli.py", line 14, in <module>
    from pecos.engines.hybrid_engine import HybridEngine  # type:ignore [import-not-found]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'pecos'
❯ pip install "quantum-pecos@git+https://github.com/PECOS-packages/PECOS.git@e2e-testing"
[...]
❯ phirc -v
Traceback (most recent call last):
  File "/private/tmp/.venv/bin/phirc", line 5, in <module>
    from pytket.phir.cli import main
  File "/private/tmp/.venv/lib/python3.11/site-packages/pytket/phir/cli.py", line 23, in <module>
    from .api import pytket_to_phir
  File "/private/tmp/.venv/lib/python3.11/site-packages/pytket/phir/api.py", line 20, in <module>
    from .rebasing.rebaser import rebase_to_qtm_machine
  File "/private/tmp/.venv/lib/python3.11/site-packages/pytket/phir/rebasing/rebaser.py", line 10, in <module>
    from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPIOffline
ModuleNotFoundError: No module named 'pytket.extensions'
```

This PR adds the missing dependency on `pytket-quantinuum`. I will need to make another minor release after merging this one.