### PR TITLE
build: phirc also needs projectq, other cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       additional_dependencies: [
         phir,
         pytest,
-        pytket-quantinuum==0.25.0,
-        pytket==1.21.0,
+        pytket-quantinuum,
+        pytket,
         types-setuptools,
       ]

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ Just issue `pip install pytket-phir` to obtain the latest stable release.
 
 The package includes a tool for emulating QASM files from the command line using PECOS.
 
-NOTE: PECOS currently requires installation using
-`pip install "quantum-pecos@git+https://github.com/PECOS-packages/PECOS.git@e2e-testing"`
-for the CLI to work.
+NOTE: The CLI currently requires installation of additional dependencies using
+`pip install projectq "quantum-pecos@git+https://github.com/PECOS-packages/PECOS.git@e2e-testing"`
 
 ```sh
 ❯ phirc -h

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = ["sphinx", "pydata_sphinx_theme"]
-# phirc = ["quantum-pecos@git+https://github.com/PECOS-packages/PECOS.git@e2e-testing"]
+phirc = ["projectq"] # add quantum-pecos>=5.0.0 once released
 tests = ["pytest"]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 build==1.0.3
 mypy==1.7.1
+networkx==2.8.8
 phir==0.1.6
 pre-commit==3.5.0
 pydata_sphinx_theme==0.14.3


### PR DESCRIPTION
Also pin `networkx` as `projectq` downgrades it.