### PR TITLE
fix(phirgen): pattern match on all possible regwise/bitwise ops

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.17.1
+    rev: v1.17.2
     hooks:
       - id: typos
 
@@ -25,7 +25,7 @@ repos:
         - black==23.10.1
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.13
+    rev: v0.1.14
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -92,20 +92,20 @@ def assign_cop(
 def regwise_cop(exp: LogicExp) -> JsonDict:
     """PHIR for classical register operations."""
     match exp.op:
+        # Bitwise
+        case RegWiseOp.AND:
+            cop = "&"
+        case RegWiseOp.OR:
+            cop = "|"
+        case RegWiseOp.NOT:
+            cop = "~"
         case RegWiseOp.XOR:
             cop = "^"
-        case RegWiseOp.ADD:
-            cop = "+"
-        case RegWiseOp.SUB:
-            cop = "-"
-        case RegWiseOp.MUL:
-            cop = "*"
-        case RegWiseOp.DIV:
-            cop = "/"
         case RegWiseOp.LSH:
             cop = "<<"
         case RegWiseOp.RSH:
             cop = ">>"
+        # Comparison
         case RegWiseOp.EQ:
             cop = "=="
         case RegWiseOp.NEQ:
@@ -118,8 +118,17 @@ def regwise_cop(exp: LogicExp) -> JsonDict:
             cop = "<="
         case RegWiseOp.GEQ:
             cop = ">="
-        case RegWiseOp.NOT:
-            cop = "~"
+        # Arithmetic
+        case RegWiseOp.ADD:
+            cop = "+"
+        case RegWiseOp.SUB | RegWiseOp.NEG:
+            cop = "-"
+        case RegWiseOp.MUL:
+            cop = "*"
+        case RegWiseOp.DIV:
+            cop = "/"
+        case RegWiseOp.POW:
+            cop = "**"
         case other:
             logging.exception("Unsupported classical operator %s", other)
             raise ValueError

--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -13,6 +13,8 @@ import logging
 from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, TypeAlias
 
+from typing_extensions import assert_never
+
 import pytket.circuit as tk
 from phir.model import PHIRModel
 from pytket.circuit.logic_exp import (
@@ -136,6 +138,8 @@ def classical_op(exp: LogicExp, *, bitwise: bool = False) -> JsonDict:
             cop = "/"
         case RegWiseOp.POW:
             cop = "**"
+        case _:
+            assert_never(exp.op)
 
     args: list[JsonDict | Var | Constant | Bit] = []
     for arg in exp.args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ mypy==1.8.0
 networkx==2.8.8
 phir==0.2.1
 pre-commit==3.6.0
-pydata_sphinx_theme==0.15.1
+pydata_sphinx_theme==0.15.2
 pytest==7.4.4
 pytket-quantinuum==0.27.0
 pytket==1.24.0
-ruff==0.1.13
+ruff==0.1.14
 setuptools_scm==8.0.4
 sphinx==7.2.6
 wheel==0.42.0

--- a/tests/test_phirgen.py
+++ b/tests/test_phirgen.py
@@ -57,3 +57,19 @@ class TestPhirGen:
             "returns": ["a"],
             "args": [{"cop": "<<", "args": ["a", 1]}],
         }
+
+    def test_bitwise_ops(self) -> None:
+        """From https://github.com/CQCL/pytket-phir/issues/91."""
+        circ = Circuit(1)
+        a = circ.add_c_register("a", 2)
+        b = circ.add_c_register("b", 2)
+        c = circ.add_c_register("c", 1)
+        expr = a[0] ^ b[0]
+        circ.add_classicalexpbox_bit(expr, [c[0]])
+
+        phir = json.loads(pytket_to_phir(circ))
+        assert phir["ops"][4] == {
+            "cop": "=",
+            "returns": [["c", 0]],
+            "args": [{"cop": "^", "args": [["a", 0], ["b", 0]]}],
+        }

--- a/tests/test_phirgen.py
+++ b/tests/test_phirgen.py
@@ -16,7 +16,7 @@ from pytket.phir.api import pytket_to_phir
 
 class TestPhirGen:
     def test_classicalexpbox(self) -> None:
-        """From https://github.com/CQCL/pytket-phir/issues/86."""
+        """From https://github.com/CQCL/pytket-phir/issues/86 ."""
         circ = Circuit(1)
         a = circ.add_c_register("a", 2)
         b = circ.add_c_register("b", 2)
@@ -31,7 +31,7 @@ class TestPhirGen:
         }
 
     def test_nested_arith(self) -> None:
-        """From https://github.com/CQCL/pytket-phir/issues/87."""
+        """From https://github.com/CQCL/pytket-phir/issues/87 ."""
         circ = Circuit(1)
         a = circ.add_c_register("a", 2)
         b = circ.add_c_register("b", 2)
@@ -46,7 +46,7 @@ class TestPhirGen:
         }
 
     def test_arith_with_int(self) -> None:
-        """From https://github.com/CQCL/pytket-phir/issues/88."""
+        """From https://github.com/CQCL/pytket-phir/issues/88 ."""
         circ = Circuit(1)
         a = circ.add_c_register("a", 2)
         circ.add_classicalexpbox_register(a << 1, a.to_list())
@@ -59,7 +59,7 @@ class TestPhirGen:
         }
 
     def test_bitwise_ops(self) -> None:
-        """From https://github.com/CQCL/pytket-phir/issues/91."""
+        """From https://github.com/CQCL/pytket-phir/issues/91 ."""
         circ = Circuit(1)
         a = circ.add_c_register("a", 2)
         b = circ.add_c_register("b", 2)


### PR DESCRIPTION
I need to confirm whether PECOS/PHIR supports the `POW` operation as [the spec](https://github.com/CQCL/phir/blob/main/spec.md#table-i---cop-assignment-arithmetic-comparison--bitwise-operations) doesn't list it.