### PR TITLE
Issue 92 Classical Ordering

### DIFF
--- a/pytket/phir/cli.py
+++ b/pytket/phir/cli.py
@@ -59,7 +59,7 @@ def main() -> None:
     for file in args.qasm_files:
         print(f"Processing {file}")  # noqa: T201
         c = circuit_from_qasm(file)
-        tket_opt_level = int(args.tk)
+        tket_opt_level = int(args.tket_opt_level)
         rc = rebase_to_qtm_machine(c, args.machine, tket_opt_level)
         qasm = circuit_to_qasm_str(rc, header="hqslib1")
         circ = circuit_from_qasm_str(qasm)

--- a/pytket/phir/sharding/sharder.py
+++ b/pytket/phir/sharding/sharder.py
@@ -194,7 +194,7 @@ class Sharder:
                     "...adding shard dep %s -> WAW", self._bit_written_by[bit_written]
                 )
                 depends_upon.add(self._bit_written_by[bit_written])
-            elif bit_written in self._bit_read_by:
+            if bit_written in self._bit_read_by:
                 logger.debug(
                     "...adding shard dep %s -> WAR", self._bit_read_by[bit_written]
                 )

--- a/tests/data/qasm/classical_ordering.qasm
+++ b/tests/data/qasm/classical_ordering.qasm
@@ -1,0 +1,11 @@
+OPENQASM 2.0;
+include "hqslib1.inc";
+
+qreg q[1];
+creg a[4];
+creg b[4];
+creg c[4];
+a = 3;
+b = a;
+c = (a - b);
+a = (a << 1);

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,6 +42,7 @@ class QasmFile(Enum):
     tk2_same_angle = auto()
     tk2_diff_angles = auto()
     rxrz = auto()
+    classical_ordering = auto()
 
 
 def get_qasm_as_circuit(qasm_file: QasmFile) -> "Circuit":


### PR DESCRIPTION
-sharder now checks for WAW and WAR instead of just one
-fixed typo in cli.py (there is no args.tk, it should be args.tk_opt_level)