### PR TITLE
issue 133 bugfix for nested bitwise ops

### DIFF
--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -144,7 +144,7 @@ def classical_op(exp: LogicExp, *, bitwise: bool = False) -> JsonDict:
     args: list[JsonDict | Var | Constant | Bit] = []
     for arg in exp.args:
         match arg:
-            case LogicExp():
+            case BitLogicExp():
                 args.append(classical_op(arg, bitwise=True))
             case BitRegister():
                 args.append(arg.name)

--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -146,9 +146,11 @@ def classical_op(exp: LogicExp, *, bitwise: bool = False) -> JsonDict:
         match arg:
             case BitLogicExp():
                 args.append(classical_op(arg, bitwise=True))
-            case RegLogicExp():
+            case LogicExp():
                 args.append(classical_op(arg))
             case BitRegister():
+                if bitwise:
+                    raise TypeError
                 args.append(arg.name)
             case Constant():
                 if bitwise and (arg < 0 or arg > 1):
@@ -159,6 +161,8 @@ def classical_op(exp: LogicExp, *, bitwise: bool = False) -> JsonDict:
                     args.append(arg_to_bit(arg))
                 else:
                     args.append(arg.reg_name)
+            case _:
+                assert_never(arg)
     return {
         "cop": cop,
         "args": args,

--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -145,10 +145,8 @@ def classical_op(exp: LogicExp, *, bitwise: bool = False) -> JsonDict:
     for arg in exp.args:
         match arg:
             case LogicExp():
-                args.append(classical_op(arg))
+                args.append(classical_op(arg, bitwise=True))
             case BitRegister():
-                if bitwise:
-                    raise TypeError
                 args.append(arg.name)
             case Constant():
                 if bitwise and (arg < 0 or arg > 1):

--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -146,6 +146,8 @@ def classical_op(exp: LogicExp, *, bitwise: bool = False) -> JsonDict:
         match arg:
             case BitLogicExp():
                 args.append(classical_op(arg, bitwise=True))
+            case RegLogicExp():
+                args.append(classical_op(arg))
             case BitRegister():
                 args.append(arg.name)
             case Constant():

--- a/tests/test_phirgen.py
+++ b/tests/test_phirgen.py
@@ -79,6 +79,32 @@ def test_bitwise_ops() -> None:
     }
 
 
+def test_nested_bitwise_op() -> None:
+    """From https://github.com/CQCL/pytket-phir/issues/133 ."""
+    circ = Circuit(4)
+    a = circ.add_c_register("a", 4)
+    b = circ.add_c_register("b", 1)
+    circ.add_classicalexpbox_bit(a[0] ^ a[1] ^ a[2] ^ a[3], [b[0]])
+
+    phir = json.loads(pytket_to_phir(circ))
+    assert phir["ops"][3] == {
+        "cop": "=",
+        "returns": [["b", 0]],
+        "args": [
+            {
+                "cop": "^",
+                "args": [
+                    {
+                        "cop": "^",
+                        "args": [{"cop": "^", "args": [["a", 0], ["a", 1]]}, ["a", 2]],
+                    },
+                    ["a", 3],
+                ],
+            }
+        ],
+    }
+
+
 def test_conditional_barrier() -> None:
     """From https://github.com/CQCL/pytket-phir/issues/119 ."""
     circ = get_qasm_as_circuit(QasmFile.cond_barrier)


### PR DESCRIPTION
recursive call in classical op is now bitwise
tests still pass after removing type error at lines 150,151 in phirgen.py

Fixes #133 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
