### PR TITLE
fix(phirgen): emit Skip mop instead of error on global phase

### DIFF
--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -175,6 +175,9 @@ def convert_subcmd(op: tk.Op, cmd: tk.Command) -> JsonDict | None:
         try:
             gate = tket_gate_to_phir[op.type]
         except KeyError:
+            if op.type == tk.OpType.Phase:
+                # ignore global phase
+                return {"mop": "Skip"}
             logging.exception("Gate %s unsupported by PHIR", op.get_name())
             raise
         angles = (op.params, "pi") if op.params else None
@@ -186,8 +189,7 @@ def convert_subcmd(op: tk.Op, cmd: tk.Command) -> JsonDict | None:
                     "returns": [arg_to_bit(cmd.bits[0])],
                     "args": [arg_to_bit(cmd.args[0])],
                 }
-            case (
-                "CX"
+            case ("CX"
                 | "CY"
                 | "CZ"
                 | "RXX"
@@ -201,7 +203,7 @@ def convert_subcmd(op: tk.Op, cmd: tk.Command) -> JsonDict | None:
                 | "SZZ"
                 | "SZZdg"
                 | "SWAP"
-            ):  # two-qubit gates
+            ):  # two-qubit gates  # fmt: skip
                 qop = {
                     "qop": gate,
                     "angles": angles,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ phir==0.3.0
 pre-commit==3.6.2
 pydata_sphinx_theme==0.15.2
 pytest==8.0.2
+pytest-order==1.2.0
 pytket==1.25.0
 ruff==0.2.2
 setuptools_scm==8.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@ networkx==2.8.8
 phir==0.3.0
 pre-commit==3.6.2
 pydata_sphinx_theme==0.15.2
-pytest==8.0.1
+pytest==8.0.2
 pytket==1.25.0
 ruff==0.2.2
 setuptools_scm==8.0.4
 sphinx==7.2.6
-wasmtime==17.0.1
+wasmtime==18.0.0
 wheel==0.42.0

--- a/tests/data/phase.json
+++ b/tests/data/phase.json
@@ -1,0 +1,2193 @@
+{
+    "bits": [
+        [
+            "index",
+            [0]
+        ],
+        [
+            "index",
+            [1]
+        ],
+        [
+            "meas_0",
+            [0]
+        ],
+        [
+            "meas_1",
+            [0]
+        ],
+        [
+            "meas_2",
+            [0]
+        ],
+        [
+            "meas_3",
+            [0]
+        ],
+        [
+            "x_corr_0",
+            [0]
+        ],
+        [
+            "x_corr_1",
+            [0]
+        ],
+        [
+            "x_corr_2",
+            [0]
+        ],
+        [
+            "x_corr_3",
+            [0]
+        ],
+        [
+            "z_corr_0",
+            [0]
+        ],
+        [
+            "z_corr_1",
+            [0]
+        ],
+        [
+            "z_corr_2",
+            [0]
+        ],
+        [
+            "z_corr_3",
+            [0]
+        ]
+    ],
+    "commands": [
+        {
+            "args": [
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "init_corrections",
+                    "n": 0,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [],
+                    "width_o_parameter": [],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_0",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_1",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_2",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_0",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_1",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_2",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [2]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "meas_2",
+                    [0]
+                ],
+                [
+                    "meas_3",
+                    [0]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "data": "",
+                "signature": ["Q","Q","Q","C","C","C","C","C","C","C","C","C","C","C","C","C","C"],
+                "type": "Barrier"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [2]
+                ]
+            ],
+            "op":
+            {
+                "type": "Reset"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [2]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1/2","-1/2"],
+                "type": "PhasedX"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [2]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1"],
+                "type": "Rz"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [2]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "meas_2",
+                    [0]
+                ],
+                [
+                    "meas_3",
+                    [0]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "data": "",
+                "signature": ["Q","Q","Q","C","C","C","C","C","C","C","C","C","C","C","C","C","C"],
+                "type": "Barrier"
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [2]
+                ],
+                [
+                    "q",
+                    [3]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "meas_2",
+                    [0]
+                ],
+                [
+                    "meas_3",
+                    [0]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "data": "",
+                "signature": ["Q","Q","Q","Q","C","C","C","C","C","C","C","C","C","C","C","C","C","C"],
+                "type": "Barrier"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [3]
+                ]
+            ],
+            "op":
+            {
+                "type": "Reset"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [3]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1/2","-1/2"],
+                "type": "PhasedX"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [3]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1"],
+                "type": "Rz"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [2]
+                ],
+                [
+                    "q",
+                    [3]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "meas_2",
+                    [0]
+                ],
+                [
+                    "meas_3",
+                    [0]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "data": "",
+                "signature": ["Q","Q","Q","Q","C","C","C","C","C","C","C","C","C","C","C","C","C","C"],
+                "type": "Barrier"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [2]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1","-1/2"],
+                "type": "PhasedX"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [3]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1","-1/2"],
+                "type": "PhasedX"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [2]
+                ]
+            ],
+            "op":
+            {
+                "params": ["0.5"],
+                "type": "ZZPhase"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [3]
+                ]
+            ],
+            "op":
+            {
+                "params": ["0.5"],
+                "type": "ZZPhase"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1/2"],
+                "type": "Rz"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [1]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1/2"],
+                "type": "Rz"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [2]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1","-1/2"],
+                "type": "PhasedX"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [3]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1","-1/2"],
+                "type": "PhasedX"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [2]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1/2"],
+                "type": "Rz"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [3]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1/2"],
+                "type": "Rz"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [2]
+                ],
+                [
+                    "q",
+                    [3]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "meas_2",
+                    [0]
+                ],
+                [
+                    "meas_3",
+                    [0]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "data": "",
+                "signature": ["Q","Q","Q","Q","C","C","C","C","C","C","C","C","C","C","C","C","C","C"],
+                "type": "Barrier"
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false,false]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "get_x_correction",
+                    "n": 3,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [2],
+                    "width_o_parameter": [1],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "get_z_correction",
+                    "n": 3,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [2],
+                    "width_o_parameter": [1],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "q",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["1","0"],
+                        "type": "PhasedX"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_0",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["0.5"],
+                        "type": "Phase"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "q",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["1"],
+                        "type": "Rz"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_0",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["0.5"],
+                        "type": "Phase"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1/2","-1/2"],
+                "type": "PhasedX"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "Measure"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [2]
+                ],
+                [
+                    "q",
+                    [3]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "meas_2",
+                    [0]
+                ],
+                [
+                    "meas_3",
+                    [0]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "data": "",
+                "signature": ["Q","Q","Q","Q","C","C","C","C","C","C","C","C","C","C","C","C","C","C"],
+                "type": "Barrier"
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false,true]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "update_x_correction",
+                    "n": 3,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [1,2],
+                    "width_o_parameter": [],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [2]
+                ],
+                [
+                    "q",
+                    [3]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "meas_2",
+                    [0]
+                ],
+                [
+                    "meas_3",
+                    [0]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "data": "",
+                "signature": ["Q","Q","Q","Q","C","C","C","C","C","C","C","C","C","C","C","C","C","C"],
+                "type": "Barrier"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [2]
+                ],
+                [
+                    "q",
+                    [3]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "meas_2",
+                    [0]
+                ],
+                [
+                    "meas_3",
+                    [0]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "data": "",
+                "signature": ["Q","Q","Q","Q","C","C","C","C","C","C","C","C","C","C","C","C","C","C"],
+                "type": "Barrier"
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [true,false]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "get_x_correction",
+                    "n": 3,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [2],
+                    "width_o_parameter": [1],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "get_z_correction",
+                    "n": 3,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [2],
+                    "width_o_parameter": [1],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["1","0"],
+                        "type": "PhasedX"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_1",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["0.5"],
+                        "type": "Phase"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["1"],
+                        "type": "Rz"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_1",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["0.5"],
+                        "type": "Phase"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [1]
+                ]
+            ],
+            "op":
+            {
+                "params": ["1/2","-1/2"],
+                "type": "PhasedX"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "Measure"
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [2]
+                ],
+                [
+                    "q",
+                    [3]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "meas_2",
+                    [0]
+                ],
+                [
+                    "meas_3",
+                    [0]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "data": "",
+                "signature": ["Q","Q","Q","Q","C","C","C","C","C","C","C","C","C","C","C","C","C","C"],
+                "type": "Barrier"
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [true,true]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "update_x_correction",
+                    "n": 3,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [1,2],
+                    "width_o_parameter": [],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "q",
+                    [0]
+                ],
+                [
+                    "q",
+                    [1]
+                ],
+                [
+                    "q",
+                    [2]
+                ],
+                [
+                    "q",
+                    [3]
+                ],
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "meas_0",
+                    [0]
+                ],
+                [
+                    "meas_1",
+                    [0]
+                ],
+                [
+                    "meas_2",
+                    [0]
+                ],
+                [
+                    "meas_3",
+                    [0]
+                ],
+                [
+                    "x_corr_0",
+                    [0]
+                ],
+                [
+                    "x_corr_1",
+                    [0]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "z_corr_0",
+                    [0]
+                ],
+                [
+                    "z_corr_1",
+                    [0]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "data": "",
+                "signature": ["Q","Q","Q","Q","C","C","C","C","C","C","C","C","C","C","C","C","C","C"],
+                "type": "Barrier"
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [false,true]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "get_x_correction",
+                    "n": 3,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [2],
+                    "width_o_parameter": [1],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "get_z_correction",
+                    "n": 3,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [2],
+                    "width_o_parameter": [1],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_2",
+                    [0]
+                ],
+                [
+                    "q",
+                    [2]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["1","0"],
+                        "type": "PhasedX"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_2",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["0.5"],
+                        "type": "Phase"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ]
+            ],
+            "op":
+            {
+                "classical":
+                {
+                    "values": [true,true]
+                },
+                "type": "SetBits"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_2",
+                    [0]
+                ],
+                [
+                    "q",
+                    [2]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["1"],
+                        "type": "Rz"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_2",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["0.5"],
+                        "type": "Phase"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "get_x_correction",
+                    "n": 3,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [2],
+                    "width_o_parameter": [1],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "index",
+                    [0]
+                ],
+                [
+                    "index",
+                    [1]
+                ],
+                [
+                    "z_corr_3",
+                    [0]
+                ],
+                [
+                    "_w",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "type": "WASM",
+                "wasm":
+                {
+                    "func_name": "get_z_correction",
+                    "n": 3,
+                    "wasm_file_uid": "89f01a2184dfa21ffb64388bd441a12e545c0e177d8312fd5780b51d501f1b4c",
+                    "width_i_parameter": [2],
+                    "width_o_parameter": [1],
+                    "ww_n": 1
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_3",
+                    [0]
+                ],
+                [
+                    "q",
+                    [3]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["1","0"],
+                        "type": "PhasedX"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "x_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["0.5"],
+                        "type": "Phase"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_3",
+                    [0]
+                ],
+                [
+                    "q",
+                    [3]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["1"],
+                        "type": "Rz"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        },
+        {
+            "args": [
+                [
+                    "z_corr_3",
+                    [0]
+                ]
+            ],
+            "op":
+            {
+                "conditional":
+                {
+                    "op":
+                    {
+                        "params": ["0.5"],
+                        "type": "Phase"
+                    },
+                    "value": 1,
+                    "width": 1
+                },
+                "type": "Conditional"
+            }
+        }
+    ],
+    "created_qubits": [],
+    "discarded_qubits": [],
+    "implicit_permutation": [
+        [
+            [
+                "q",
+                [0]
+            ],
+            [
+                "q",
+                [0]
+            ]
+        ],
+        [
+            [
+                "q",
+                [1]
+            ],
+            [
+                "q",
+                [1]
+            ]
+        ],
+        [
+            [
+                "q",
+                [2]
+            ],
+            [
+                "q",
+                [2]
+            ]
+        ],
+        [
+            [
+                "q",
+                [3]
+            ],
+            [
+                "q",
+                [3]
+            ]
+        ]
+    ],
+    "number_of_ws": 1,
+    "phase": "0.5",
+    "qubits": [
+        [
+            "q",
+            [0]
+        ],
+        [
+            "q",
+            [1]
+        ],
+        [
+            "q",
+            [2]
+        ],
+        [
+            "q",
+            [3]
+        ]
+    ]
+}

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -15,6 +15,8 @@ import logging
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
+import pytest
+
 from pytket.circuit import Circuit
 from pytket.phir.api import pytket_to_phir, qasm_to_phir
 from pytket.phir.qtm_machine import QtmMachine
@@ -62,6 +64,7 @@ class TestWASM:
             "returns": ["co"],
         }
 
+    @pytest.mark.order("first")
     def test_pytket_with_wasm(self) -> None:
         wasm_bytes = get_wat_as_wasm_bytes(WatFile.testfile)
         phir_str: str


### PR DESCRIPTION
# Description

We currently error out on (global) Phase, which is a problem as global phase is a harmless operation. I propose a no-op `mop` instruction `"Skip"` instead to handle this scenario.

Fixes #136

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
