### PR TITLE
feat(phirgen): add support for Sleep/Idle mop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.18.2
+    rev: v1.19.0
     hooks:
       - id: typos
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "phir>=0.3.0",
+  "phir>=0.3.1",
   "pytket>=1.21.0",
   "wasmtime>=15.0.0",
   ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-build==1.0.3
+build==1.1.1
 mypy==1.8.0
 networkx==2.8.8
-phir==0.3.0
+phir==0.3.1
 pre-commit==3.6.2
 pydata_sphinx_theme==0.15.2
 pytest==8.0.2
@@ -10,5 +10,5 @@ pytket==1.25.0
 ruff==0.2.2
 setuptools_scm==8.0.4
 sphinx==7.2.6
-wasmtime==18.0.0
+wasmtime==18.0.2
 wheel==0.42.0

--- a/tests/data/qasm/sleep.qasm
+++ b/tests/data/qasm/sleep.qasm
@@ -1,0 +1,17 @@
+OPENQASM 2.0;
+include "hqslib1_dev.inc";
+
+qreg q[1];
+creg c[1];
+
+rx(pi/2) q[0];
+
+barrier q[0];
+sleep(1) q[0];
+barrier q[0];
+
+rx(-pi/2) q[0];
+
+barrier q[0];
+
+measure q -> c;

--- a/tests/test_parallelization.py
+++ b/tests/test_parallelization.py
@@ -10,6 +10,8 @@
 
 import logging
 
+import pytest
+
 from .test_utils import QasmFile, get_phir_json
 
 logger = logging.getLogger(__name__)
@@ -156,6 +158,7 @@ def test_two_qubit_exec_order_preserved() -> None:
     }
 
 
+@pytest.mark.order("first")
 def test_group_ordering() -> None:
     """Test that groups are in the right order when the group number can decrement."""
     phir = get_phir_json(QasmFile.group_ordering, rebase=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,6 +51,7 @@ class QasmFile(Enum):
     cond_barrier = auto()
     arbitrary_qreg_names = auto()
     group_ordering = auto()
+    sleep = auto()
 
 
 class WatFile(Enum):


### PR DESCRIPTION
# Description

Add support for QASM's `sleep` operation that gets converted by pytket into a barrier with `op.data` carrying the sleep information. We convert it into the existing PHIR `"Idle"` `"mop"`.

Also update several dependencies.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
