### PR TITLE
fix(phirgen): don't rely on `args` when `qubits` carries correct info

### DIFF
--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -187,7 +187,7 @@ def convert_gate(op: tk.Op, cmd: tk.Command) -> JsonDict | None:
             qop = {
                 "qop": gate,
                 "returns": [arg_to_bit(cmd.bits[0])],
-                "args": [arg_to_bit(cmd.args[0])],
+                "args": [arg_to_bit(cmd.qubits[0])],
             }
         case ("CX"
             | "CY"

--- a/tests/test_phirgen.py
+++ b/tests/test_phirgen.py
@@ -174,3 +174,17 @@ def test_reordering_classical_conditional() -> None:
         "condition": {"args": [["ctrl", 0], 1], "cop": "=="},
         "true_branch": [{"angles": None, "args": [["q", 0]], "qop": "X"}],
     }
+
+
+def test_conditional_measure() -> None:
+    """From https://github.com/CQCL/pytket-phir/issues/154 ."""
+    c = Circuit(2, 2)
+    c.H(0).H(1)
+    c.Measure(0, 0)
+    c.Measure(1, 1, condition_bits=[0], condition_value=1)
+    phir = json.loads(pytket_to_phir(c))
+    assert phir["ops"][-1] == {
+        "block": "if",
+        "condition": {"cop": "==", "args": [["c", 0], 1]},
+        "true_branch": [{"qop": "Measure", "returns": [["c", 1]], "args": [["q", 1]]}],
+    }


### PR DESCRIPTION
# Description

Fixes #154

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog with any user-facing changes
