### PR TITLE
fix(wasm): correct arguments for conditional wasm functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         - black==23.10.1
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.3.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.19.0
+    rev: v1.20.1
     hooks:
       - id: typos
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,6 @@ version_scheme = "python-simplified-semver"
 
 [tool.refurb]
 python_version = "3.10"
+
+[tool.typos]
+default.extend-words = { lst = "lst" }

--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -230,11 +230,11 @@ def convert_subcmd(op: tk.Op, cmd: tk.Command) -> JsonDict | None:
                 # See https://github.com/CQCL/tket/blob/0ec603986821d994caa3a0fb9c4640e5bc6c0a24/pytket/pytket/qasm/qasm.py#L419-L459
                 match op.data[0:5]:
                     case "sleep":
-                        dur = op.data.removeprefix("sleep(").removesuffix(")")
+                        duration = op.data.removeprefix("sleep(").removesuffix(")")
                         out = {
                             "mop": "Idle",
                             "args": [arg_to_bit(qbit) for qbit in cmd.qubits],
-                            "duration": (float(dur), "s"),
+                            "duration": (float(duration), "s"),
                         }
                     case "order" | "group":
                         raise NotImplementedError(op.data)

--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -386,7 +386,7 @@ def make_comment_text(cmd: tk.Command, op: tk.Op) -> str:
 
         case tk.WASMOp():
             args, returns = extract_wasm_args_and_returns(cmd, op)
-            comment = f"WASM_function={op.func_name} args={args} returns={returns};"
+            comment = f"WASM_function='{op.func_name}' args={args} returns={returns};"
 
         case tk.BarrierOp():
             comment = op.data + " " + str(cmd.args[0]) + ";" if op.data else str(cmd)

--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -375,9 +375,18 @@ def make_comment_text(cmd: tk.Command, op: tk.Op) -> str:
     """Converts a command + op to the PHIR comment spec."""
     comment = str(cmd)
     match op:
+        case tk.Conditional():
+            conditional_text = str(cmd)
+            cleaned = (
+                conditional_text[: conditional_text.find("THEN") + 5]
+                if isinstance(op.op, tk.WASMOp)
+                else ""
+            )
+            comment = f"{cleaned}{make_comment_text(cmd, op.op)}"
+
         case tk.WASMOp():
             args, returns = extract_wasm_args_and_returns(cmd, op)
-            comment = f"WASM function={op.func_name} args={args} returns={returns}"
+            comment = f"WASM_function={op.func_name} args={args} returns={returns};"
 
         case tk.BarrierOp():
             comment = op.data + " " + str(cmd.args[0]) + ";" if op.data else str(cmd)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pydata_sphinx_theme==0.15.2
 pytest==8.1.1
 pytest-order==1.2.0
 pytket==1.26.0
-ruff==0.3.4
+ruff==0.3.5
 setuptools_scm==8.0.4
 sphinx==7.2.6
 wasmtime==19.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-build==1.1.1
+build==1.2.1
 mypy==1.9.0
 networkx==2.8.8
 phir==0.3.2

--- a/tests/test_parallelization.py
+++ b/tests/test_parallelization.py
@@ -64,18 +64,18 @@ def test_parallel_subcommand_relative_ordering() -> None:
     phir = get_phir_json(QasmFile.rxrz, rebase=True)
     # make sure it is ordered like the qasm file
     ops = phir["ops"]
-    frst_sc = ops[3]
-    scnd_sc = ops[5]
-    thrd_sc = ops[7]
-    frth_sc = ops[9]
-    assert frst_sc["qop"] == "RZ"
-    assert frst_sc["angles"] == [[0.5], "pi"]
-    assert scnd_sc["qop"] == "R1XY"
-    assert scnd_sc["angles"] == [[3.5, 0.0], "pi"]
-    assert thrd_sc["qop"] == "R1XY"
-    assert thrd_sc["angles"] == [[0.5, 0.0], "pi"]
-    assert frth_sc["qop"] == "RZ"
-    assert frth_sc["angles"] == [[3.5], "pi"]
+    sc1 = ops[3]
+    sc2 = ops[5]
+    sc3 = ops[7]
+    sc4 = ops[9]
+    assert sc1["qop"] == "RZ"
+    assert sc1["angles"] == [[0.5], "pi"]
+    assert sc2["qop"] == "R1XY"
+    assert sc2["angles"] == [[3.5, 0.0], "pi"]
+    assert sc3["qop"] == "R1XY"
+    assert sc3["angles"] == [[0.5, 0.0], "pi"]
+    assert sc4["qop"] == "RZ"
+    assert sc4["angles"] == [[3.5], "pi"]
 
 
 def test_single_qubit_circuit_with_parallel() -> None:

--- a/tests/test_phirgen.py
+++ b/tests/test_phirgen.py
@@ -92,6 +92,18 @@ def test_conditional_barrier() -> None:
     }
 
 
+def test_simple_cond_classical() -> None:
+    """Ensure conditional classical operation are correctly generated."""
+    circ = get_qasm_as_circuit(QasmFile.simple_cond)
+    phir = json.loads(pytket_to_phir(circ))
+    assert phir["ops"][-6] == {"//": "IF ([c[0]] == 1) THEN SetBits(1) z[0];"}
+    assert phir["ops"][-5] == {
+        "block": "if",
+        "condition": {"cop": "==", "args": [["c", 0], 1]},
+        "true_branch": [{"cop": "=", "returns": [["z", 0]], "args": [1]}],
+    }
+
+
 def test_nested_bitwise_op() -> None:
     """From https://github.com/CQCL/pytket-phir/issues/133 ."""
     circ = Circuit(4)

--- a/tests/test_phirgen.py
+++ b/tests/test_phirgen.py
@@ -183,6 +183,7 @@ def test_conditional_measure() -> None:
     c.Measure(0, 0)
     c.Measure(1, 1, condition_bits=[0], condition_value=1)
     phir = json.loads(pytket_to_phir(c))
+    assert phir["ops"][-2] == {"//": "IF ([c[0]] == 1) THEN Measure q[1] --> c[1];"}
     assert phir["ops"][-1] == {
         "block": "if",
         "condition": {"cop": "==", "args": [["c", 0], 1]},

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -27,112 +27,116 @@ from .test_utils import WatFile, get_wat_as_wasm_bytes
 logger = logging.getLogger(__name__)
 
 
-class TestWASM:
-    def test_qasm_to_phir_with_wasm(self) -> None:
-        """Test the qasm string entrypoint works with WASM."""
-        qasm = """
-        OPENQASM 2.0;
-        include "qelib1.inc";
+def test_qasm_to_phir_with_wasm() -> None:
+    """Test the qasm string entrypoint works with WASM."""
+    qasm = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
 
-        qreg q[2];
-        h q;
-        ZZ q[1],q[0];
-        creg cr[3];
-        creg cs[3];
-        creg co[3];
-        measure q[0]->cr[0];
-        measure q[1]->cr[1];
+    qreg q[2];
+    h q;
+    ZZ q[1],q[0];
+    creg cr[3];
+    creg cs[3];
+    creg co[3];
+    measure q[0]->cr[0];
+    measure q[1]->cr[1];
 
-        cs = cr;
-        co = add(cr, cs);
-        """
+    cs = cr;
+    co = add(cr, cs);
+    """
 
-        wasm_bytes = get_wat_as_wasm_bytes(WatFile.add)
+    wasm_bytes = get_wat_as_wasm_bytes(WatFile.add)
 
-        wasm_uid = hashlib.sha256(base64.b64encode(wasm_bytes)).hexdigest()
+    wasm_uid = hashlib.sha256(base64.b64encode(wasm_bytes)).hexdigest()
 
-        phir_str = qasm_to_phir(qasm, QtmMachine.H1, wasm_bytes=wasm_bytes)
-        phir = json.loads(phir_str)
+    phir_str = qasm_to_phir(qasm, QtmMachine.H1, wasm_bytes=wasm_bytes)
+    phir = json.loads(phir_str)
 
-        expected_metadata = {"ff_object": (f"WASM module uid: {wasm_uid}")}
+    expected_metadata = {"ff_object": (f"WASM module uid: {wasm_uid}")}
 
-        assert phir["ops"][21] == {
-            "metadata": expected_metadata,
-            "cop": "ffcall",
-            "function": "add",
-            "args": ["cr", "cs"],
-            "returns": ["co"],
-        }
+    assert phir["ops"][21] == {
+        "metadata": expected_metadata,
+        "cop": "ffcall",
+        "function": "add",
+        "args": ["cr", "cs"],
+        "returns": ["co"],
+    }
 
-    @pytest.mark.order("first")
-    def test_pytket_with_wasm(self) -> None:
-        wasm_bytes = get_wat_as_wasm_bytes(WatFile.testfile)
-        phir_str: str
-        try:
-            wasm_file = NamedTemporaryFile(suffix=".wasm", delete=False)
-            wasm_file.write(wasm_bytes)
-            wasm_file.flush()
-            wasm_file.close()
 
-            w = WasmFileHandler(wasm_file.name)
+@pytest.mark.order("first")
+def test_pytket_with_wasm() -> None:
+    """Test whether pytket works with WASM."""
+    wasm_bytes = get_wat_as_wasm_bytes(WatFile.testfile)
+    phir_str: str
+    try:
+        wasm_file = NamedTemporaryFile(suffix=".wasm", delete=False)
+        wasm_file.write(wasm_bytes)
+        wasm_file.flush()
+        wasm_file.close()
 
-            c = Circuit(6, 6)
-            c0 = c.add_c_register("c0", 3)
-            c1 = c.add_c_register("c1", 4)
-            c2 = c.add_c_register("c2", 5)
+        w = WasmFileHandler(wasm_file.name)
 
-            c.add_wasm_to_reg("multi", w, [c0, c1], [c2])
-            c.add_wasm_to_reg("add_one", w, [c2], [c2])
-            c.add_wasm_to_reg("no_return", w, [c2], [])
-            c.add_wasm_to_reg("no_parameters", w, [], [c2])
+        c = Circuit(6, 6)
+        c0 = c.add_c_register("c0", 3)
+        c1 = c.add_c_register("c1", 4)
+        c2 = c.add_c_register("c2", 5)
 
-            c.add_wasm_to_reg("add_one", w, [c0], [c0], condition=c1[0])
+        c.add_wasm_to_reg("multi", w, [c0, c1], [c2])
+        c.add_wasm_to_reg("add_one", w, [c2], [c2])
+        c.add_wasm_to_reg("no_return", w, [c2], [])
+        c.add_wasm_to_reg("no_parameters", w, [], [c2])
 
-            phir_str = pytket_to_phir(c, QtmMachine.H1)
-        finally:
-            Path.unlink(Path(wasm_file.name))
+        c.add_wasm_to_reg("add_one", w, [c0], [c0], condition=c1[0])
 
-        phir = json.loads(phir_str)
+        phir_str = pytket_to_phir(c, QtmMachine.H1)
+    finally:
+        Path.unlink(Path(wasm_file.name))
 
-        expected_metadata = {"ff_object": (f"WASM module uid: {w!s}")}
+    phir = json.loads(phir_str)
 
-        assert phir["ops"][4] == {
-            "metadata": expected_metadata,
-            "cop": "ffcall",
-            "function": "multi",
-            "args": ["c0", "c1"],
-            "returns": ["c2"],
-        }
-        assert phir["ops"][7] == {
-            "metadata": expected_metadata,
-            "cop": "ffcall",
-            "function": "add_one",
-            "args": ["c2"],
-            "returns": ["c2"],
-        }
-        assert phir["ops"][9] == {
-            "block": "if",
-            "condition": {"cop": "==", "args": [["c1", 0], 1]},
-            "true_branch": [
-                {
-                    "metadata": expected_metadata,
-                    "cop": "ffcall",
-                    "returns": ["c0"],
-                    "function": "add_one",
-                    "args": ["c1", "c0"],
-                }
-            ],
-        }
-        assert phir["ops"][12] == {
-            "metadata": expected_metadata,
-            "cop": "ffcall",
-            "function": "no_return",
-            "args": ["c2"],
-        }
-        assert phir["ops"][15] == {
-            "metadata": expected_metadata,
-            "cop": "ffcall",
-            "function": "no_parameters",
-            "args": [],
-            "returns": ["c2"],
-        }
+    expected_metadata = {"ff_object": (f"WASM module uid: {w!s}")}
+
+    assert phir["ops"][4] == {
+        "metadata": expected_metadata,
+        "cop": "ffcall",
+        "function": "multi",
+        "args": ["c0", "c1"],
+        "returns": ["c2"],
+    }
+    assert phir["ops"][7] == {
+        "metadata": expected_metadata,
+        "cop": "ffcall",
+        "function": "add_one",
+        "args": ["c2"],
+        "returns": ["c2"],
+    }
+    assert phir["ops"][8] == {
+        "//": "IF ([c1[0]] == 1) THEN WASM_function=add_one args=['c1', 'c0'] returns=['c0'];"  # noqa: E501
+    }
+    assert phir["ops"][9] == {
+        "block": "if",
+        "condition": {"cop": "==", "args": [["c1", 0], 1]},
+        "true_branch": [
+            {
+                "metadata": expected_metadata,
+                "cop": "ffcall",
+                "returns": ["c0"],
+                "function": "add_one",
+                "args": ["c1", "c0"],
+            }
+        ],
+    }
+    assert phir["ops"][12] == {
+        "metadata": expected_metadata,
+        "cop": "ffcall",
+        "function": "no_return",
+        "args": ["c2"],
+    }
+    assert phir["ops"][15] == {
+        "metadata": expected_metadata,
+        "cop": "ffcall",
+        "function": "no_parameters",
+        "args": [],
+        "returns": ["c2"],
+    }


### PR DESCRIPTION
# Description

- pyket API for arguments is quite fragile, we needed to eliminate bits used in the condition  to extract the correct bits used in the WASM function.
- I had unknowingly removed the Conditional case in #152, it was needed for WASM conditional handling in comments.

Fixes #156

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog with any user-facing changes
