### PR TITLE
do nothing on Init gate instead of warning

### DIFF
--- a/pytket/phir/phirgen_parallel.py
+++ b/pytket/phir/phirgen_parallel.py
@@ -292,6 +292,8 @@ def adjust_phir_transport_time(ops: list["JsonDict"], machine: "Machine") -> Non
                     adjustment += machine.tq_time
                 case "Measure":
                     adjustment += machine.meas_prep_time
+                case "Init":
+                    pass  # Init does not have a duration
                 case _:
                     logger.warning(
                         "Gate type %s not assigned a transport duration", op["qop"]
@@ -303,6 +305,8 @@ def adjust_phir_transport_time(ops: list["JsonDict"], machine: "Machine") -> Non
                     adjustment += machine.sq_time
                 case "RZZ":
                     adjustment += machine.tq_time
+                case "Init":
+                    pass  # Init does not have a duration
                 case _:
                     logger.warning(
                         "Gate type %s not assigned a transport duration", first_op


### PR DESCRIPTION
# Description

Do not display a "No transport duration assigned to gate type 'Init'" warning, it is unnecessary. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog with any user-facing changes
