### PR TITLE
fix: Use a context manager for opening files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.23.6
+    rev: v1.23.7
     hooks:
       - id: typos
 
@@ -25,7 +25,7 @@ repos:
         - black==23.10.1
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.1
+    rev: v0.6.2
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pytket/phir/api.py
+++ b/pytket/phir/api.py
@@ -9,7 +9,6 @@
 # mypy: disable-error-code="misc"
 
 import logging
-from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
@@ -90,22 +89,18 @@ def qasm_to_phir(
     """
     circuit: Circuit
     if wasm_bytes:
-        try:
-            qasm_file = NamedTemporaryFile(suffix=".qasm", delete=False)
-            wasm_file = NamedTemporaryFile(suffix=".wasm", delete=False)
+        with (
+            NamedTemporaryFile(suffix=".qasm", delete=False) as qasm_file,
+            NamedTemporaryFile(suffix=".wasm", delete=False) as wasm_file,
+        ):
             qasm_file.write(qasm.encode())
             qasm_file.flush()
-            qasm_file.close()
             wasm_file.write(wasm_bytes)
             wasm_file.flush()
-            wasm_file.close()
 
             circuit = circuit_from_qasm_wasm(
                 qasm_file.name, wasm_file.name, maxwidth=WORDSIZE
             )
-        finally:
-            Path.unlink(Path(qasm_file.name))
-            Path.unlink(Path(wasm_file.name))
     else:
         circuit = circuit_from_qasm_str(qasm, maxwidth=WORDSIZE)
     return pytket_to_phir(circuit, qtm_machine)

--- a/pytket/phir/rebasing/rebaser.py
+++ b/pytket/phir/rebasing/rebaser.py
@@ -8,8 +8,7 @@
 
 from typing import TYPE_CHECKING
 
-from pytket.passes import DecomposeBoxes
-from pytket.passes.auto_rebase import auto_rebase_pass
+from pytket.passes import AutoRebase, DecomposeBoxes
 from pytket.phir.qtm_machine import QTM_DEFAULT_GATESET, QTM_MACHINES_MAP, QtmMachine
 
 if TYPE_CHECKING:
@@ -22,5 +21,5 @@ def rebase_to_qtm_machine(circuit: "Circuit", qtm_machine: QtmMachine) -> "Circu
     gateset = QTM_DEFAULT_GATESET if machine is None else machine.gateset
     c = circuit.copy()
     DecomposeBoxes().apply(c)
-    auto_rebase_pass(gateset, allow_swaps=True).apply(c)
+    AutoRebase(gateset, allow_swaps=True).apply(c)
     return c

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,9 @@ phir==0.3.3
 pre-commit==3.8.0
 pydata_sphinx_theme==0.15.4
 pytest==8.3.2
-pytest-order==1.2.1
 pytket==1.31.1
-ruff==0.6.1
+ruff==0.6.2
 setuptools_scm==8.1.0
 sphinx==8.0.2
-wasmtime==23.0.0
+wasmtime==24.0.0
 wheel==0.44.0

--- a/tests/test_parallelization.py
+++ b/tests/test_parallelization.py
@@ -10,8 +10,6 @@
 
 import logging
 
-import pytest
-
 from .test_utils import QasmFile, get_phir_json
 
 logger = logging.getLogger(__name__)
@@ -158,7 +156,6 @@ def test_two_qubit_exec_order_preserved() -> None:
     }
 
 
-@pytest.mark.order("first")
 def test_group_ordering() -> None:
     """Test that groups are in the right order when the group number can decrement."""
     phir = get_phir_json(QasmFile.group_ordering, rebase=True)


### PR DESCRIPTION
# Description

`ruff` [pointed out](https://github.com/CQCL/pytket-phir/actions/runs/10517561194/job/29141900659) errors like the following:
```
pytket/phir/api.py:94:25: SIM115 Use a context manager for opening files
   |
92 |     if wasm_bytes:
93 |         try:
94 |             qasm_file = NamedTemporaryFile(suffix=".qasm", delete=False)
   |                         ^^^^^^^^^^^^^^^^^^ SIM115
95 |             wasm_file = NamedTemporaryFile(suffix=".wasm", delete=False)
96 |             qasm_file.write(qasm.encode())
   |
```

Turns out resolving these also fixes #108.

Additionally:
- fixes warning "DeprecationWarning: The `auto_rebase_pass()` method is deprecated and will be removed after pytket 1.33, please use `AutoRebase` instead."
- update deps

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog with any user-facing changes
