### PR TITLE
refactor: use WasmModuleHandler API to avoid temp files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.26.0
+    rev: v1.26.8
     hooks:
       - id: typos
 
@@ -25,7 +25,7 @@ repos:
         - black==23.10.1
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.7.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -37,7 +37,7 @@ repos:
       - id: refurb
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.11.2'
+    rev: 'v1.13.0'
     hooks:
     - id: mypy
       pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "phir>=0.3.2",
-  "pytket>=1.21.0",
+  "pytket>=1.34.0",
   "wasmtime>=15.0.0",
   ]
 

--- a/pytket/phir/phirgen.py
+++ b/pytket/phir/phirgen.py
@@ -51,7 +51,7 @@ JsonDict: TypeAlias = dict[str, Any]
 PHIR_HEADER: JsonDict = {
     "format": "PHIR/JSON",
     "version": "0.1.0",
-    "metadata": {"source": f'pytket-phir v{version("pytket-phir").split("+")[0]}'},
+    "metadata": {"source": f"pytket-phir v{version('pytket-phir').split('+')[0]}"},
 }
 
 WASM_WORDSIZE = 32

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 build==1.2.2.post1
-mypy==1.11.2
+mypy==1.13.0
 networkx<3
 phir==0.3.3
-pre-commit==4.0.0
-pydata_sphinx_theme==0.15.4
+pre-commit==4.0.1
+pydata_sphinx_theme==0.16.0
 pytest==8.3.3
-pytket==1.33.0
-ruff==0.6.9
+pytket==1.34.0
+ruff==0.7.1
 setuptools_scm==8.1.0
 wasmtime==25.0.0
 wheel==0.44.0


### PR DESCRIPTION
# Description

Remove use of unnecessary `NamedTemporaryFile` as pytket>=1.34 allows supports `WasmModuleHandler` that does not require a file interface.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog with any user-facing changes
