### PR TITLE
Constrain to pytket 1.x.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "phir>=0.3.3",
-  "pytket>=1.34.0",
+  "pytket>=1.34.0,<2",
   "wasmtime>=19.0.0",
   ]
 


### PR DESCRIPTION
After pytket 2.0 is released we should be able to change to "pytket>=2.0.0" and remove the handling of, and tests involving, `ClassicalExpBox` in this repo.